### PR TITLE
Fix Boolean default values to "false" as reported in issue #15

### DIFF
--- a/scheduler-component.html
+++ b/scheduler-component.html
@@ -83,7 +83,7 @@
           },
           allDaySlot: {
             type: Boolean,
-            value: true
+            value: false
           },
           allDayText: {
             type: String,
@@ -109,7 +109,7 @@
           },
           slotEventOverlap: {
             type: Boolean,
-            value: true
+            value: false
           },
           nowIndicator: Boolean,
           dragRevertDuration: {
@@ -122,7 +122,7 @@
           },
           dragScroll: {
             type: Boolean,
-            value: true
+            value: false
           },
           eventOverlap: Object,
           eventConstraint: Object,


### PR DESCRIPTION
Component attributes are "true" if set and "false" if not.
Therefore, default values of "true" can never be set to "false" through attributes.
Explained more in detail here:
https://github.com/Polymer/polymer/issues/1812#issuecomment-112226630