### PR TITLE
Fire "date-range-changed" event when the visible date range has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ The scheduler element dispatches the events below :
 | `event-resize-end` | *{ event, jsEvent, ui, view }* | Fired when resize operation on one event is ended.                                                                                                      |
 | `event-resize` | *{ event, delta, revertFunc, jsEvent, ui, view }* | Fired when an event has been resized                                                                                   |
 | `view-render` | *{ view, element }* | Dispatched when the view of the scheduler is rendered. A navigation between days, weeks or months will fire this event                                                                                    |
+| `date-range-changed` | *{ start, end}* | Dispatched when the visible date range of the scheduler has changed, e.g. a navigation between days, weeks or months. Parameters are date strings in the ISO format (e.g. 2017-08-26). This event is fired in the same situations as the "view-render" event and exists for developers' convenience. |
 | `view-destroy` | *{ view, element }* | Dispatched when the view is destroyed.                                                                               |
 
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -60,6 +60,9 @@
   scheduler.addEventListener("view-render", function (e) {
     console.log("view is rendered");
   });
+  scheduler.addEventListener("date-range-changed", function (e) {
+    console.log("date range changed", e.detail.start, e.detail.end);
+  });
 
   function next() {
     scheduler.today();

--- a/scheduler-component.html
+++ b/scheduler-component.html
@@ -248,7 +248,9 @@
           },
           viewRender: (view, element) => {
             this.dispatchEvent(new CustomEvent('view-render', { detail: { view, element } }));
-
+            const start = view.activeRange.start.toISOString();
+            const end = view.activeRange.end.toISOString();
+            this.dispatchEvent(new CustomEvent('date-range-changed', { detail: { start, end } }));
           },
           viewDestroy: (view, element) => {
             this.dispatchEvent(new CustomEvent('view-destroy', { detail: { view, element } }));


### PR DESCRIPTION
It's fired in the same situations as "view-render", but with a clear
name it's easier to understand when to use it.

Issue #17