### PR TITLE
fix for when events are null

### DIFF
--- a/scheduler-component.html
+++ b/scheduler-component.html
@@ -265,6 +265,8 @@
           },
           viewRender: (view, element) => {
             this.dispatchEvent(new CustomEvent('view-render', { detail: { view, element } }));
+            if (view.activeRange == null) return;
+
             const start = view.activeRange.start.toISOString();
             const end = view.activeRange.end.toISOString();
             this.dispatchEvent(new CustomEvent('date-range-changed', { detail: { start, end } }));


### PR DESCRIPTION
since the latest 1.5.0 release, the component does not support if the event's value is null or undefined. This is important to be able to support for cases where the component is fully rendered prior to the data being fully available. IE: if the events and categories are generated via Iron-ajax calls.

This is a simple fix to work around code introduced in 1.5.0 which broke this support.