### PR TITLE
category UI to handle multi-line and show a simpler style for hidden …

### DIFF
--- a/categories-element.html
+++ b/categories-element.html
@@ -11,10 +11,10 @@
             }
 
             .categories-container {
-                height: 30px;
                 width: 100%;
                 background-color: #f5f5f5;
                 margin-top: 1px;
+                padding-bottom: 5px;
                 position: relative;
             }
 

--- a/category-element.html
+++ b/category-element.html
@@ -28,8 +28,7 @@
             .disabled {
                 pointer-events: none !important;
                 cursor: none !important;
-                opacity: 0.5;
-                background: #CCC;
+                opacity: 0.3;
             }
         </style>
         <div id="categoryContainer" class$="category {{disabledStyle()}}">


### PR DESCRIPTION
Noticed the category bar did not support if the categories wrapped to a second line due to a fixed height. this change allows for the bar to expand to accommodate.

I also adjusted how hidden categories are displayed as a felt the background box looked out of place. This is perhaps a personal preference though, so if there are concerns I can remove this adjustment.