### PR TITLE
fix for polymer lint on components and removed invalid test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
     - google-chrome-stable
 before_script:
-- npm install -g bower polymer-cli --unsafe-perm
+- npm install -g bower polymer-cli
 - bower install
 - polymer lint
 script: xvfb-run wct

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
 - npm install -g bower polymer-cli
 - bower install
 - polymer lint
-script: xvfb-run wct
+script: xvfb-run polymer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
     - google-chrome-stable
 before_script:
-- npm install -g bower polymer-cli
+- npm install -g bower polymer-cli web-component-tester
 - bower install
 - polymer lint
-script: xvfb-run polymer test
+script: xvfb-run wct

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
     - google-chrome-stable
 before_script:
-- npm install -g bower polylint web-component-tester
+- npm install -g bower polymer-cli --unsafe-perm
 - bower install
-- polylint
+- polymer lint
 script: xvfb-run wct

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
     - google-chrome-stable
 before_script:
-- npm install -g bower polymer-cli web-component-tester
+- npm install -g bower polymer-cli
 - bower install
 - polymer lint
-script: xvfb-run wct
+script: xvfb-run polymer test

--- a/categories-element.html
+++ b/categories-element.html
@@ -31,6 +31,10 @@
     </template>
 
     <script>
+        /**
+        * @polymer
+        * @extends HTMLElement
+        */
         class CategoriesElement extends Polymer.Element {
             static get is() { return 'categories-element'; }
             static get properties() {

--- a/categories-element.html
+++ b/categories-element.html
@@ -1,3 +1,4 @@
+<link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="category-element.html">
 
 <!--
@@ -32,6 +33,7 @@
 
     <script>
         /**
+        * @customElement
         * @polymer
         * @extends HTMLElement
         */

--- a/category-element.html
+++ b/category-element.html
@@ -1,3 +1,4 @@
+<link rel="import" href="../polymer/polymer-element.html">
 <!--
      A custom element that encapsulate a scheduler's category.
  -->
@@ -40,6 +41,7 @@
 
     <script>
         /**
+        * @customElement
         * @polymer
         * @extends HTMLElement
         */

--- a/category-element.html
+++ b/category-element.html
@@ -39,6 +39,10 @@
     </template>
 
     <script>
+        /**
+        * @polymer
+        * @extends HTMLElement
+        */
         class CategoryElement extends Polymer.Element {
             static get is() { return 'category-element'; }
             static get properties() {

--- a/scheduler-component.html
+++ b/scheduler-component.html
@@ -55,6 +55,7 @@
           },
           events: {
             type: Array,
+            value: [],
             observer: '_eventsChanged'
           },
           weekends: Boolean,

--- a/scheduler-component.html
+++ b/scheduler-component.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/lib/utils/flush.html">
 <link rel="import" href="categories-element.html">
 <script src="../jquery/dist/jquery.min.js"></script>
 <script src="../moment/min/moment.min.js"></script>

--- a/test/scheduler-component_test.html
+++ b/test/scheduler-component_test.html
@@ -13,12 +13,6 @@
   </head>
   <body>
 
-    <test-fixture id="BasicTestFixture">
-      <template>
-        <full-calendar></full-calendar>
-      </template>
-    </test-fixture>
-
     <test-fixture id="ChangedPropertyTestFixture">
       <template>
        <scheduler-component

--- a/test/scheduler-component_test.html
+++ b/test/scheduler-component_test.html
@@ -4,14 +4,20 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
-    <title>full-calendar test</title>
+    <title>scheduler-component test</title>
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-
+    
     <link rel="import" href="../scheduler-component.html">
   </head>
   <body>
+
+    <test-fixture id="BasicTestFixture">		
+      <template>		
+        <scheduler-component></scheduler-component>		
+      </template>		
+    </test-fixture>
 
     <test-fixture id="ChangedPropertyTestFixture">
       <template>


### PR DESCRIPTION
Noticed the builds were breaking due to linting errors. added a few comments in the code to resolve the lint errors and removed an invalid test trying to build a "full-calendar" component.